### PR TITLE
Newsletter CRUD endpointy vcetne admin, validace. Pridana funkce na hledani root projektu do main.go

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -24,49 +23,16 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func findProjectRoot() (string, error) {
-	// Start from the current working directory
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	// Look for go.mod file to identify project root
-	currentDir := wd
-	for {
-		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
-			return currentDir, nil
-		}
-
-		// Go up one directory
-		parentDir := filepath.Dir(currentDir)
-		if parentDir == currentDir {
-			// We've reached the root directory
-			return "", fmt.Errorf("could not find project root (no go.mod file found)")
-		}
-		currentDir = parentDir
-	}
-}
-
 func main() {
 	// Initialize logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
 
-	// Find project root and load environment variables
-	projectRoot, err := findProjectRoot()
-	if err != nil {
-		logger.Error("Failed to find project root", "error", err)
-		os.Exit(1)
+	// Load environment variables
+	if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
+		logger.Warn("Error loading .env file", "error", err)
 	}
-
-	envPath := filepath.Join(projectRoot, ".env")
-	if err := godotenv.Load(envPath); err != nil {
-		logger.Error("Error loading .env file", "error", err, "path", envPath)
-		os.Exit(1)
-	}
-	logger.Info("Successfully loaded .env file", "path", envPath)
 
 	// Setup server configuration
 	port := utils.GetEnvWithDefault("PORT", "8080")
@@ -85,10 +51,10 @@ func main() {
 	// Initialize dependencies using dependency injection
 	profileRepo := repository.NewProfileRepository(dbpool, logger)
 	newsletterRepo := repository.NewNewsletterRepository(dbpool, logger)
+	newsletterService := services.NewNewsletterService(newsletterRepo, logger)
 	profileService := services.NewProfileService(profileRepo, logger)
 	authService := services.NewAuthService(cfg.Supabase.JWTSecret, logger)
 	mailingService := services.NewMailingService(&cfg.Resend, logger)
-	newsletterService := services.NewNewsletterService(newsletterRepo, logger)
 	apiServer := server.NewServer(profileService, authService, cfg, logger, mailingService, newsletterService)
 
 	// Initialize router and middleware

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,10 +84,12 @@ func main() {
 
 	// Initialize dependencies using dependency injection
 	profileRepo := repository.NewProfileRepository(dbpool, logger)
+	newsletterRepo := repository.NewNewsletterRepository(dbpool, logger)
 	profileService := services.NewProfileService(profileRepo, logger)
 	authService := services.NewAuthService(cfg.Supabase.JWTSecret, logger)
 	mailingService := services.NewMailingService(&cfg.Resend, logger)
-	apiServer := server.NewServer(profileService, authService, cfg, logger, mailingService)
+	newsletterService := services.NewNewsletterService(newsletterRepo, logger)
+	apiServer := server.NewServer(profileService, authService, cfg, logger, mailingService, newsletterService)
 
 	// Initialize router and middleware
 	r := setupRouter(logger, apiServer)

--- a/internal/config/newsletter_config.go
+++ b/internal/config/newsletter_config.go
@@ -1,0 +1,41 @@
+package config
+
+// NewsletterConfig contains all business rules and constants for the newsletter domain
+type NewsletterConfig struct {
+	// Name constraints
+	MaxNameLength        int
+	MinNameLength        int
+	RequiredNameMessage  string
+	TooLongNameMessage   string
+	TooShortNameMessage  string
+	EmptyNameMessage     string
+	DuplicateNameMessage string
+
+	// Description constraints
+	MaxDescriptionLength int
+	TooLongDescMessage   string
+
+	// ID constraints
+	InvalidIDMessage string
+}
+
+// DefaultNewsletterConfig returns the default configuration for newsletters
+func DefaultNewsletterConfig() *NewsletterConfig {
+	return &NewsletterConfig{
+		// Name constraints
+		MaxNameLength:        100,
+		MinNameLength:        1,
+		RequiredNameMessage:  "Newsletter name is required",
+		TooLongNameMessage:   "Newsletter name must be less than 100 characters",
+		TooShortNameMessage:  "Newsletter name must be at least 1 character",
+		EmptyNameMessage:     "Newsletter name cannot be empty",
+		DuplicateNameMessage: "You already have a newsletter with this name",
+
+		// Description constraints
+		MaxDescriptionLength: 500,
+		TooLongDescMessage:   "Description must be less than 500 characters",
+
+		// ID constraints
+		InvalidIDMessage: "Invalid newsletter ID format",
+	}
+}

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"encoding/json"
+	"go-newsletter/internal/models"
+	"go-newsletter/internal/services"
+	"go-newsletter/internal/utils"
+	"go-newsletter/pkg/generated"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type NewsletterHandler struct {
+	service   *services.NewsletterService
+	responder *utils.HTTPResponder
+}
+
+func NewNewsletterHandler(service *services.NewsletterService, logger *slog.Logger) *NewsletterHandler {
+	return &NewsletterHandler{
+		service:   service,
+		responder: utils.NewHTTPResponder(logger),
+	}
+}
+
+func (h *NewsletterHandler) GetNewslettersOwnedByEditor(w http.ResponseWriter, r *http.Request) {
+	user, ok := services.GetUserFromContext(r.Context())
+	if !ok {
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("User not authenticated"))
+		return
+	}
+
+	newsletters, err := h.service.GetNewslettersOwnedByEditor(r.Context(), user.UserID.String())
+	if err != nil {
+		h.responder.HandleError(w, r, err)
+		return
+	}
+
+	var newslettersResponse []generated.Newsletter
+	for _, newsletter := range newsletters {
+		newslettersResponse = append(newslettersResponse, newsletter)
+	}
+
+	h.responder.RespondJSON(w, http.StatusOK, newslettersResponse)
+}
+
+func (h *NewsletterHandler) GetNewsletterByID(w http.ResponseWriter, r *http.Request) {
+	user, ok := services.GetUserFromContext(r.Context())
+	if !ok {
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("User not authenticated"))
+		return
+	}
+
+	newsletterId := chi.URLParam(r, "newsletterId")
+	if newsletterId == "" {
+		h.responder.HandleError(w, r, models.NewBadRequestError("Newsletter ID is required"))
+		return
+	}
+
+	newsletter, err := h.service.GetNewsletterByID(r.Context(), newsletterId, user.UserID.String())
+	if err != nil {
+		h.responder.HandleError(w, r, err)
+		return
+	}
+
+	h.responder.RespondJSON(w, http.StatusOK, newsletter)
+}
+
+func (h *NewsletterHandler) PostNewsletters(w http.ResponseWriter, r *http.Request) {
+	user, ok := services.GetUserFromContext(r.Context())
+	if !ok {
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("User not authenticated"))
+		return
+	}
+
+	// Decode request body
+	var req generated.NewsletterCreate
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.responder.HandleError(w, r, models.NewBadRequestError("Invalid JSON payload"))
+		return
+	}
+
+	// Create newsletter
+	newsletter, err := h.service.CreateNewsletter(r.Context(), user.UserID.String(), req)
+	if err != nil {
+		h.responder.HandleError(w, r, err)
+		return
+	}
+
+	h.responder.RespondJSON(w, http.StatusCreated, newsletter)
+}

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -39,12 +39,7 @@ func (h *NewsletterHandler) GetNewslettersOwnedByEditor(w http.ResponseWriter, r
 		return
 	}
 
-	var newslettersResponse []generated.Newsletter
-	for _, newsletter := range newsletters {
-		newslettersResponse = append(newslettersResponse, newsletter)
-	}
-
-	h.responder.RespondJSON(w, http.StatusOK, newslettersResponse)
+	h.responder.RespondJSON(w, http.StatusOK, newsletters)
 }
 
 func (h *NewsletterHandler) GetNewsletterByID(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -27,7 +27,7 @@ func NewNewsletterHandler(service *services.NewsletterService, logger *slog.Logg
 func (h *NewsletterHandler) GetNewslettersOwnedByEditor(w http.ResponseWriter, r *http.Request) {
 	user, ok := services.GetUserFromContext(r.Context())
 	if !ok {
-		h.responder.HandleError(w, r, models.NewUnauthorizedError("HANDLER: HANDLER: User not authenticated"))
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("HANDLER: User not authenticated"))
 		return
 	}
 
@@ -52,13 +52,13 @@ func (h *NewsletterHandler) GetNewsletterByID(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	newsletterId := chi.URLParam(r, "newsletterId")
-	if newsletterId == "" {
+	newsletterID := chi.URLParam(r, "newsletterId")
+	if newsletterID == "" {
 		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Newsletter ID is required"))
 		return
 	}
 
-	newsletter, err := h.service.GetNewsletterByID(r.Context(), newsletterId, user.UserID.String())
+	newsletter, err := h.service.GetNewsletterByID(r.Context(), newsletterID, user.UserID.String())
 	if err != nil {
 		h.responder.HandleError(w, r, err)
 		return
@@ -74,14 +74,12 @@ func (h *NewsletterHandler) PostNewsletters(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Decode request body
 	var req generated.NewsletterCreate
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Invalid JSON payload"))
 		return
 	}
 
-	// Create newsletter
 	newsletter, err := h.service.CreateNewsletter(r.Context(), user.UserID.String(), req)
 	if err != nil {
 		h.responder.HandleError(w, r, err)
@@ -110,13 +108,13 @@ func (h *NewsletterHandler) PutNewsletters(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	newsletterId := chi.URLParam(r, "newsletterId")
-	if newsletterId == "" {
+	newsletterID := chi.URLParam(r, "newsletterId")
+	if newsletterID == "" {
 		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Newsletter ID is required"))
 		return
 	}
 
-	newsletter, err := h.service.UpdateNewsletter(r.Context(), user.UserID.String(), newsletterId, req)
+	newsletter, err := h.service.UpdateNewsletter(r.Context(), user.UserID.String(), newsletterID, req)
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			h.responder.HandleError(w, r, models.NewNotFoundError("HANDLER: Newsletter not found"))

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -27,7 +27,7 @@ func NewNewsletterHandler(service *services.NewsletterService, logger *slog.Logg
 func (h *NewsletterHandler) GetNewslettersOwnedByEditor(w http.ResponseWriter, r *http.Request) {
 	user, ok := services.GetUserFromContext(r.Context())
 	if !ok {
-		h.responder.HandleError(w, r, models.NewUnauthorizedError("User not authenticated"))
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("HANDLER: HANDLER: User not authenticated"))
 		return
 	}
 
@@ -48,13 +48,13 @@ func (h *NewsletterHandler) GetNewslettersOwnedByEditor(w http.ResponseWriter, r
 func (h *NewsletterHandler) GetNewsletterByID(w http.ResponseWriter, r *http.Request) {
 	user, ok := services.GetUserFromContext(r.Context())
 	if !ok {
-		h.responder.HandleError(w, r, models.NewUnauthorizedError("User not authenticated"))
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("HANDLER: User not authenticated"))
 		return
 	}
 
 	newsletterId := chi.URLParam(r, "newsletterId")
 	if newsletterId == "" {
-		h.responder.HandleError(w, r, models.NewBadRequestError("Newsletter ID is required"))
+		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Newsletter ID is required"))
 		return
 	}
 
@@ -70,20 +70,50 @@ func (h *NewsletterHandler) GetNewsletterByID(w http.ResponseWriter, r *http.Req
 func (h *NewsletterHandler) PostNewsletters(w http.ResponseWriter, r *http.Request) {
 	user, ok := services.GetUserFromContext(r.Context())
 	if !ok {
-		h.responder.HandleError(w, r, models.NewUnauthorizedError("User not authenticated"))
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("HANDLER: User not authenticated"))
 		return
 	}
 
 	// Decode request body
 	var req generated.NewsletterCreate
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		h.responder.HandleError(w, r, models.NewBadRequestError("Invalid JSON payload"))
+		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Invalid JSON payload"))
 		return
 	}
 
 	// Create newsletter
 	newsletter, err := h.service.CreateNewsletter(r.Context(), user.UserID.String(), req)
 	if err != nil {
+		h.responder.HandleError(w, r, err)
+		return
+	}
+
+	h.responder.RespondJSON(w, http.StatusCreated, newsletter)
+}
+
+func (h *NewsletterHandler) PutNewsletters(w http.ResponseWriter, r *http.Request) {
+	user, ok := services.GetUserFromContext(r.Context())
+	if !ok {
+		h.responder.HandleError(w, r, models.NewUnauthorizedError("HANDLER: User not authenticated"))
+		return
+	}
+
+	var req generated.NewsletterUpdate
+	// TODO partial update
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Invalid JSON payload"))
+		return
+	}
+
+	newsletterId := chi.URLParam(r, "newsletterId")
+	if newsletterId == "" {
+		h.responder.HandleError(w, r, models.NewBadRequestError("HANDLER: Newsletter ID is required"))
+		return
+	}
+
+	newsletter, err := h.service.UpdateNewsletter(r.Context(), user.UserID.String(), newsletterId, req)
+	if err != nil {
+		// TODO return 404 when not found (curr. 500)
 		h.responder.HandleError(w, r, err)
 		return
 	}

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -99,12 +99,6 @@ func (h *NewsletterHandler) PutNewsletters(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Validate that at least one field is provided for update
-	if req.Name == nil && req.Description == nil {
-		h.responder.HandleError(w, r, models.NewBadRequestError("At least one field (name or description) must be provided for update"))
-		return
-	}
-
 	newsletterID := chi.URLParam(r, "newsletterId")
 	if newsletterID == "" {
 		h.responder.HandleError(w, r, models.NewBadRequestError("Newsletter ID is required"))

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -33,3 +33,11 @@ func NewConflictError(message string) APIError {
 func NewInternalServerError(message string) APIError {
 	return APIError{Code: 500, Message: message}
 }
+
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	apiErr, ok := err.(APIError)
+	return ok && apiErr.Code == 404
+}

--- a/internal/repository/newsletter_repository.go
+++ b/internal/repository/newsletter_repository.go
@@ -88,8 +88,7 @@ func (r *NewsletterRepository) GetByID(ctx context.Context, newsletterID string)
 
 }
 
-// TODO rename newsletter arg to newsletterCreate
-func (r *NewsletterRepository) Create(ctx context.Context, editorID string, newsletter *generated.NewsletterCreate) (*generated.Newsletter, error) {
+func (r *NewsletterRepository) Create(ctx context.Context, editorID string, newsletterCreate *generated.NewsletterCreate) (*generated.Newsletter, error) {
 	query := `
 	INSERT INTO public.newsletters (id, name, description, editor_id, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6)
@@ -103,8 +102,8 @@ func (r *NewsletterRepository) Create(ctx context.Context, editorID string, news
 	var n generated.Newsletter
 	err := r.db.QueryRow(ctx, query,
 		id,
-		newsletter.Name,
-		newsletter.Description,
+		newsletterCreate.Name,
+		newsletterCreate.Description,
 		editorID,
 		now,
 		now,

--- a/internal/repository/newsletter_repository.go
+++ b/internal/repository/newsletter_repository.go
@@ -62,14 +62,14 @@ func (r *NewsletterRepository) GetNewslettersOwnedByEditor(ctx context.Context, 
 
 }
 
-func (r *NewsletterRepository) GetByID(ctx context.Context, id string) (*generated.Newsletter, error) {
+func (r *NewsletterRepository) GetByID(ctx context.Context, newsletterID string) (*generated.Newsletter, error) {
 	query := `
 		SELECT id, name, description, editor_id, created_at, updated_at
 		FROM public.newsletters
 		WHERE id = $1
 	`
 	var n generated.Newsletter
-	err := r.db.QueryRow(ctx, query, id).Scan(
+	err := r.db.QueryRow(ctx, query, newsletterID).Scan(
 		&n.Id,
 		&n.Name,
 		&n.Description,
@@ -78,10 +78,10 @@ func (r *NewsletterRepository) GetByID(ctx context.Context, id string) (*generat
 		&n.UpdatedAt)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			r.logger.ErrorContext(ctx, "REPO: Newsletter not found", "id", id)
+			r.logger.ErrorContext(ctx, "REPO: Newsletter not found", "id", newsletterID)
 			return nil, models.NewNotFoundError("Newsletter not found")
 		}
-		r.logger.ErrorContext(ctx, "REPO: Failed to get newsletter by ID", "id", id, "error", err)
+		r.logger.ErrorContext(ctx, "REPO: Failed to get newsletter by ID", "id", newsletterID, "error", err)
 		return nil, err
 	}
 	return &n, nil

--- a/internal/repository/newsletter_repository.go
+++ b/internal/repository/newsletter_repository.go
@@ -82,6 +82,7 @@ func (r *NewsletterRepository) GetByID(ctx context.Context, id string) (*generat
 
 }
 
+// TODO rename newsletter arg to newsletterCreate
 func (r *NewsletterRepository) Create(ctx context.Context, editorID string, newsletter *generated.NewsletterCreate) (*generated.Newsletter, error) {
 	query := `
 	INSERT INTO public.newsletters (id, name, description, editor_id, created_at, updated_at)
@@ -112,6 +113,32 @@ func (r *NewsletterRepository) Create(ctx context.Context, editorID string, news
 
 	if err != nil {
 		r.logger.Error("REPO: failed to create newsletter", "error", err)
+		return nil, err
+	}
+
+	return &n, nil
+}
+
+// TODO unify camel case in editorID
+func (r *NewsletterRepository) Update(ctx context.Context, newsletterID string, newsletterUpdate *generated.NewsletterUpdate) (*generated.Newsletter, error) {
+	query := `
+		UPDATE public.newsletters
+		SET name = $2, description = $3, updated_at = $4
+		WHERE id = $1
+		RETURNING id, name, description, editor_id, created_at, updated_at
+	`
+	now := time.Now()
+	var n generated.Newsletter
+	err := r.db.QueryRow(ctx, query, newsletterID, newsletterUpdate.Name, newsletterUpdate.Description, now).Scan(
+		&n.Id,
+		&n.Name,
+		&n.Description,
+		&n.EditorId,
+		&n.CreatedAt,
+		&n.UpdatedAt,
+	)
+	if err != nil {
+		r.logger.Error("REPO: failed to update newsletter", "error", err)
 		return nil, err
 	}
 

--- a/internal/repository/newsletter_repository.go
+++ b/internal/repository/newsletter_repository.go
@@ -1,0 +1,119 @@
+package repository
+
+import (
+	"context"
+	"go-newsletter/pkg/generated"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type NewsletterRepository struct {
+	db     *pgxpool.Pool
+	logger *slog.Logger
+}
+
+func NewNewsletterRepository(db *pgxpool.Pool, logger *slog.Logger) *NewsletterRepository {
+	return &NewsletterRepository{
+		db:     db,
+		logger: logger,
+	}
+}
+
+// Retrieves a list of newsletters owned by the authenticated editor.
+func (r *NewsletterRepository) GetNewslettersOwnedByEditor(ctx context.Context, editorID string) ([]generated.Newsletter, error) {
+	query := `
+		SELECT id, name, description, editor_id, created_at, updated_at
+		FROM public.newsletters
+		WHERE editor_id = $1
+		ORDER BY created_at DESC
+	`
+	rows, err := r.db.Query(ctx, query, editorID)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "REPO: Failed to get all newsletters", "error", err)
+		return nil, err
+	}
+	defer rows.Close()
+	var newsletters []generated.Newsletter
+	for rows.Next() {
+		var n generated.Newsletter
+		if err := rows.Scan(&n.Id,
+			&n.Name,
+			&n.Description,
+			&n.EditorId,
+			&n.CreatedAt,
+			&n.UpdatedAt); err != nil {
+			r.logger.ErrorContext(ctx, "Failed to scan newsletter row", "error", err)
+			return nil, err
+		}
+		newsletters = append(newsletters, n)
+	}
+
+	if err := rows.Err(); err != nil {
+		r.logger.ErrorContext(ctx, "Error iterating newsletter rows", "error", err)
+		return nil, err
+	}
+
+	return newsletters, nil
+
+}
+
+func (r *NewsletterRepository) GetByID(ctx context.Context, id string) (*generated.Newsletter, error) {
+	query := `
+		SELECT id, name, description, editor_id, created_at, updated_at
+		FROM public.newsletters
+		WHERE id = $1
+	`
+	var n generated.Newsletter
+	err := r.db.QueryRow(ctx, query, id).Scan(
+		&n.Id,
+		&n.Name,
+		&n.Description,
+		&n.EditorId,
+		&n.CreatedAt,
+		&n.UpdatedAt)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "REPO: Failed to get newsletter by ID", "id", id, "error", err)
+		return nil, err
+	}
+	return &n, nil
+
+}
+
+func (r *NewsletterRepository) Create(ctx context.Context, editorID string, newsletter *generated.NewsletterCreate) (*generated.Newsletter, error) {
+	query := `
+	INSERT INTO public.newsletters (id, name, description, editor_id, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, name, description, editor_id, created_at, updated_at
+	`
+
+	// ProfileRepo uses SQL NOW() func for this part.
+	id := uuid.New()
+	now := time.Now()
+
+	var n generated.Newsletter
+	err := r.db.QueryRow(ctx, query,
+		id,
+		newsletter.Name,
+		newsletter.Description,
+		editorID,
+		now,
+		now,
+	).Scan(
+		&n.Id,
+		&n.Name,
+		&n.Description,
+		&n.EditorId,
+		&n.CreatedAt,
+		&n.UpdatedAt,
+	)
+
+	if err != nil {
+		r.logger.Error("REPO: failed to create newsletter", "error", err)
+		return nil, err
+	}
+
+	return &n, nil
+}

--- a/internal/repository/newsletter_repository.go
+++ b/internal/repository/newsletter_repository.go
@@ -125,7 +125,6 @@ func (r *NewsletterRepository) Create(ctx context.Context, editorID string, news
 	return &n, nil
 }
 
-// TODO unify camel case in editorID
 func (r *NewsletterRepository) Update(ctx context.Context, newsletterID string, newsletterUpdate *generated.NewsletterUpdate) (*generated.Newsletter, error) {
 	// First get the current newsletter to handle partial updates
 	current, err := r.GetByID(ctx, newsletterID)
@@ -166,4 +165,24 @@ func (r *NewsletterRepository) Update(ctx context.Context, newsletterID string, 
 	}
 
 	return &n, nil
+}
+
+func (r *NewsletterRepository) Delete(ctx context.Context, newsletterID string) error {
+	query := `
+		DELETE FROM public.newsletters
+		WHERE id = $1
+	`
+	result, err := r.db.Exec(ctx, query, newsletterID)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "REPO: failed to delete newsletter", "id", newsletterID, "error", err)
+		return err
+	}
+
+	rowsAffected := result.RowsAffected()
+	if rowsAffected == 0 {
+		r.logger.ErrorContext(ctx, "REPO: Newsletter not found for deletion", "id", newsletterID)
+		return models.NewNotFoundError("Newsletter not found")
+	}
+
+	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,7 @@ func NewServer(profileService *services.ProfileService, authService *services.Au
 		authHandler:       handlers.NewAuthHandler(authService, logger),
 		authService:       authService,
 		mailingService:    mailingService,
-		newsletterHandler: handlers.NewNewsletterHandler(newsletterService, logger),
+		newsletterHandler: handlers.NewNewsletterHandler(newsletterService, profileService, logger),
 		responder:         utils.NewHTTPResponder(logger),
 		logger:            logger,
 	}
@@ -48,11 +48,11 @@ func (s *Server) PutMe(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) GetAdminNewsletters(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.GetAllNewsletters(w, r)
 }
 
 func (s *Server) DeleteAdminNewslettersNewsletterId(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.DeleteNewsletterByID(w, r)
 }
 
 func (s *Server) GetAdminUsers(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -107,8 +107,9 @@ func (s *Server) GetNewslettersNewsletterId(w http.ResponseWriter, r *http.Reque
 	s.newsletterHandler.GetNewsletterByID(w, r)
 }
 
+// PutNewslettersNewsletterId handles PUT /newsletters/{newsletterId}
 func (s *Server) PutNewslettersNewsletterId(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.PutNewsletters(w, r)
 }
 
 func (s *Server) GetNewslettersNewsletterIdPosts(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,7 +99,7 @@ func (s *Server) PostNewsletters(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) DeleteNewslettersNewsletterId(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.DeleteNewsletter(w, r)
 }
 
 // GetNewsletters handles GET /newsletters/{newsletterId}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,23 +13,25 @@ import (
 
 // Server implements the generated ServerInterface
 type Server struct {
-	profileHandler *handlers.ProfileHandler
-	authHandler    *handlers.AuthHandler
-	authService    *services.AuthService
-	mailingService *services.MailingService
-	responder      *utils.HTTPResponder
-	logger         *slog.Logger // Keep logger for non-HTTP operations
+	profileHandler    *handlers.ProfileHandler
+	authHandler       *handlers.AuthHandler
+	authService       *services.AuthService
+	mailingService    *services.MailingService
+	newsletterHandler *handlers.NewsletterHandler
+	responder         *utils.HTTPResponder
+	logger            *slog.Logger // Keep logger for non-HTTP operations
 }
 
 // NewServer creates a new server instance
-func NewServer(profileService *services.ProfileService, authService *services.AuthService, cfg *config.Config, logger *slog.Logger, mailingService *services.MailingService) *Server {
+func NewServer(profileService *services.ProfileService, authService *services.AuthService, cfg *config.Config, logger *slog.Logger, mailingService *services.MailingService, newsletterService *services.NewsletterService) *Server {
 	return &Server{
-		profileHandler: handlers.NewProfileHandler(profileService, authService, logger),
-		authHandler:    handlers.NewAuthHandler(authService, logger),
-		authService:    authService,
-		mailingService: mailingService,
-		responder:      utils.NewHTTPResponder(logger),
-		logger:         logger,
+		profileHandler:    handlers.NewProfileHandler(profileService, authService, logger),
+		authHandler:       handlers.NewAuthHandler(authService, logger),
+		authService:       authService,
+		mailingService:    mailingService,
+		newsletterHandler: handlers.NewNewsletterHandler(newsletterService, logger),
+		responder:         utils.NewHTTPResponder(logger),
+		logger:            logger,
 	}
 }
 
@@ -86,20 +88,23 @@ func (s *Server) PostAuthPasswordResetRequest(w http.ResponseWriter, r *http.Req
 	s.authHandler.PostAuthPasswordResetRequest(w, r)
 }
 
+// GetNewsletters handles GET /newsletters - get newsletters owned by current editor
 func (s *Server) GetNewsletters(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.GetNewslettersOwnedByEditor(w, r)
 }
 
+// PostNewsletters handles POST /newsletters - create newsletter
 func (s *Server) PostNewsletters(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.PostNewsletters(w, r)
 }
 
 func (s *Server) DeleteNewslettersNewsletterId(w http.ResponseWriter, r *http.Request) {
 	s.notImplemented(w, r)
 }
 
+// GetNewsletters handles GET /newsletters/{newsletterId}
 func (s *Server) GetNewslettersNewsletterId(w http.ResponseWriter, r *http.Request) {
-	s.notImplemented(w, r)
+	s.newsletterHandler.GetNewsletterByID(w, r)
 }
 
 func (s *Server) PutNewslettersNewsletterId(w http.ResponseWriter, r *http.Request) {

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -20,8 +20,8 @@ func NewNewsletterService(repo *repository.NewsletterRepository, logger *slog.Lo
 	}
 }
 
-func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, editorId string) ([]generated.Newsletter, error) {
-	newsletters, err := s.repo.GetNewslettersOwnedByEditor(ctx, editorId)
+func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, editorID string) ([]generated.Newsletter, error) {
+	newsletters, err := s.repo.GetNewslettersOwnedByEditor(ctx, editorID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "SERVICE: failed to find newsletters of current editor", "error", err)
 		return nil, err
@@ -34,17 +34,17 @@ func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, edi
 	return result, nil
 }
 
-func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterId string, editorId string) (*generated.Newsletter, error) {
-	newsletter, err := s.repo.GetByID(ctx, newsletterId)
+func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterID string, editorID string) (*generated.Newsletter, error) {
+	newsletter, err := s.repo.GetByID(ctx, newsletterID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "SERVICE: failed to get newsletter by ID", "error", err)
 		return nil, err
 	}
 
 	// Check if the requesting user is the editor of this newsletter
-	if newsletter.EditorId.String() != editorId {
+	if newsletter.EditorId.String() != editorID {
 		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
-			"requested_editor_id", editorId,
+			"requested_editor_id", editorID,
 			"newsletter_editor_id", newsletter.EditorId.String())
 		return nil, models.NewForbiddenError("SERVICE: You don't have access to this newsletter")
 	}
@@ -52,8 +52,8 @@ func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterId 
 	return newsletter, nil
 }
 
-func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorId string, newsletterCreate generated.NewsletterCreate) (*generated.Newsletter, error) {
-	newsletter, err := s.repo.Create(ctx, editorId, &newsletterCreate)
+func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorID string, newsletterCreate generated.NewsletterCreate) (*generated.Newsletter, error) {
+	newsletter, err := s.repo.Create(ctx, editorID, &newsletterCreate)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "SERVICE: failed to create newsletter", "error", err)
 		return nil, err
@@ -61,12 +61,12 @@ func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorId strin
 	return newsletter, nil
 }
 
-func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorId string, newsletterId string, newsletterUpdate generated.NewsletterUpdate) (*generated.Newsletter, error) {
+func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorID string, newsletterID string, newsletterUpdate generated.NewsletterUpdate) (*generated.Newsletter, error) {
 	// First check if the newsletter exists and user has access
-	newsletter, err := s.repo.GetByID(ctx, newsletterId)
+	newsletter, err := s.repo.GetByID(ctx, newsletterID)
 	if err != nil {
 		if models.IsNotFoundError(err) {
-			s.logger.ErrorContext(ctx, "SERVICE: Newsletter not found", "id", newsletterId)
+			s.logger.ErrorContext(ctx, "SERVICE: Newsletter not found", "id", newsletterID)
 			return nil, err
 		}
 		s.logger.ErrorContext(ctx, "SERVICE: failed to get newsletter", "error", err)
@@ -74,15 +74,15 @@ func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorId strin
 	}
 
 	// Check if the requesting user is the editor of this newsletter
-	if newsletter.EditorId.String() != editorId {
+	if newsletter.EditorId.String() != editorID {
 		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
-			"requested_editor_id", editorId,
+			"requested_editor_id", editorID,
 			"newsletter_editor_id", newsletter.EditorId.String())
 		return nil, models.NewForbiddenError("SERVICE: You don't have access to this newsletter")
 	}
 
 	// Proceed with update
-	updatedNewsletter, err := s.repo.Update(ctx, newsletterId, &newsletterUpdate)
+	updatedNewsletter, err := s.repo.Update(ctx, newsletterID, &newsletterUpdate)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "SERVICE: failed to update newsletter", "error", err)
 		return nil, err

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -119,3 +119,20 @@ func (s *NewsletterService) DeleteNewsletter(ctx context.Context, editorID strin
 
 	return nil
 }
+
+func (s *NewsletterService) AdminGetAllNewsletters(ctx context.Context) ([]generated.Newsletter, error) {
+	newsletters, err := s.repo.AdminGetAll(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "SERVICE: failed to get all newsletters", "error", err)
+		return nil, err
+	}
+	return newsletters, nil
+}
+
+func (s *NewsletterService) AdminDeleteNewsletterByID(ctx context.Context, newsletterID string) error {
+	if err := s.repo.AdminDeleteByID(ctx, newsletterID); err != nil {
+		s.logger.ErrorContext(ctx, "SERVICE: failed to delete newsletter", "error", err)
+		return err
+	}
+	return nil
+}

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -26,12 +26,7 @@ func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, edi
 		s.logger.ErrorContext(ctx, "SERVICE: failed to find newsletters of current editor", "error", err)
 		return nil, err
 	}
-
-	var result []generated.Newsletter
-	for _, n := range newsletters {
-		result = append(result, n)
-	}
-	return result, nil
+	return newsletters, nil
 }
 
 func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterID string, editorID string) (*generated.Newsletter, error) {

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -2,22 +2,101 @@ package services
 
 import (
 	"context"
+	"go-newsletter/internal/config"
 	"go-newsletter/internal/models"
 	"go-newsletter/internal/repository"
 	"go-newsletter/pkg/generated"
 	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Validation errors
+var (
+	ErrNameRequired   = models.NewBadRequestError("Newsletter name is required")
+	ErrNameTooLong    = models.NewBadRequestError("Newsletter name must be less than 100 characters")
+	ErrDescTooLong    = models.NewBadRequestError("Description must be less than 500 characters")
+	ErrInvalidID      = models.NewBadRequestError("Invalid newsletter ID format")
+	ErrNoUpdateFields = models.NewBadRequestError("At least one field (name or description) must be provided for update")
+	ErrEmptyName      = models.NewBadRequestError("Newsletter name cannot be empty")
 )
 
 type NewsletterService struct {
 	repo   *repository.NewsletterRepository
 	logger *slog.Logger
+	config *config.NewsletterConfig
 }
 
 func NewNewsletterService(repo *repository.NewsletterRepository, logger *slog.Logger) *NewsletterService {
 	return &NewsletterService{
 		repo:   repo,
 		logger: logger,
+		config: config.DefaultNewsletterConfig(),
 	}
+}
+
+// validateNewsletterCreate validates the newsletter creation request
+func (s *NewsletterService) validateNewsletterCreate(ctx context.Context, editorID string, newsletter generated.NewsletterCreate) error {
+	if strings.TrimSpace(newsletter.Name) == "" {
+		return models.NewBadRequestError(s.config.RequiredNameMessage)
+	}
+	if len(newsletter.Name) > s.config.MaxNameLength {
+		return models.NewBadRequestError(s.config.TooLongNameMessage)
+	}
+	if len(newsletter.Name) < s.config.MinNameLength {
+		return models.NewBadRequestError(s.config.TooShortNameMessage)
+	}
+	if newsletter.Description != nil && len(*newsletter.Description) > s.config.MaxDescriptionLength {
+		return models.NewBadRequestError(s.config.TooLongDescMessage)
+	}
+
+	// Check for duplicate name
+	exists, err := s.repo.CheckDuplicateName(ctx, editorID, newsletter.Name, "")
+	if err != nil {
+		return err
+	}
+	if exists {
+		return models.NewBadRequestError(s.config.DuplicateNameMessage)
+	}
+
+	return nil
+}
+
+// validateNewsletterUpdate validates the newsletter update request
+func (s *NewsletterService) validateNewsletterUpdate(ctx context.Context, editorID string, newsletterID string, update generated.NewsletterUpdate) error {
+	if update.Name != nil {
+		if strings.TrimSpace(*update.Name) == "" {
+			return models.NewBadRequestError(s.config.EmptyNameMessage)
+		}
+		if len(*update.Name) > s.config.MaxNameLength {
+			return models.NewBadRequestError(s.config.TooLongNameMessage)
+		}
+		if len(*update.Name) < s.config.MinNameLength {
+			return models.NewBadRequestError(s.config.TooShortNameMessage)
+		}
+
+		// Check for duplicate name
+		exists, err := s.repo.CheckDuplicateName(ctx, editorID, *update.Name, newsletterID)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return models.NewBadRequestError(s.config.DuplicateNameMessage)
+		}
+	}
+	if update.Description != nil && len(*update.Description) > s.config.MaxDescriptionLength {
+		return models.NewBadRequestError(s.config.TooLongDescMessage)
+	}
+	return nil
+}
+
+// validateNewsletterID validates the newsletter ID format
+func (s *NewsletterService) validateNewsletterID(id string) error {
+	if _, err := uuid.Parse(id); err != nil {
+		return models.NewBadRequestError(s.config.InvalidIDMessage)
+	}
+	return nil
 }
 
 func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, editorID string) ([]generated.Newsletter, error) {
@@ -30,6 +109,11 @@ func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, edi
 }
 
 func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterID string, editorID string) (*generated.Newsletter, error) {
+	// Validate input
+	if err := s.validateNewsletterID(newsletterID); err != nil {
+		return nil, err
+	}
+
 	newsletter, err := s.repo.GetByID(ctx, newsletterID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "SERVICE: failed to get newsletter by ID", "error", err)
@@ -48,6 +132,11 @@ func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterID 
 }
 
 func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorID string, newsletterCreate generated.NewsletterCreate) (*generated.Newsletter, error) {
+	// Validate input
+	if err := s.validateNewsletterCreate(ctx, editorID, newsletterCreate); err != nil {
+		return nil, err
+	}
+
 	newsletter, err := s.repo.Create(ctx, editorID, &newsletterCreate)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "SERVICE: failed to create newsletter", "error", err)
@@ -57,6 +146,14 @@ func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorID strin
 }
 
 func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorID string, newsletterID string, newsletterUpdate generated.NewsletterUpdate) (*generated.Newsletter, error) {
+	// Validate input
+	if err := s.validateNewsletterID(newsletterID); err != nil {
+		return nil, err
+	}
+	if err := s.validateNewsletterUpdate(ctx, editorID, newsletterID, newsletterUpdate); err != nil {
+		return nil, err
+	}
+
 	// First check if the newsletter exists and user has access
 	newsletter, err := s.repo.GetByID(ctx, newsletterID)
 	if err != nil {
@@ -87,6 +184,11 @@ func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorID strin
 }
 
 func (s *NewsletterService) DeleteNewsletter(ctx context.Context, editorID string, newsletterID string) error {
+	// Validate input
+	if err := s.validateNewsletterID(newsletterID); err != nil {
+		return err
+	}
+
 	// First check if the newsletter exists and user has access
 	newsletter, err := s.repo.GetByID(ctx, newsletterID)
 	if err != nil {

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -46,7 +46,7 @@ func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterID 
 		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
 			"requested_editor_id", editorID,
 			"newsletter_editor_id", newsletter.EditorId.String())
-		return nil, models.NewForbiddenError("SERVICE: You don't have access to this newsletter")
+		return nil, models.NewForbiddenError("You don't have access to this newsletter")
 	}
 
 	return newsletter, nil
@@ -78,7 +78,7 @@ func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorID strin
 		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
 			"requested_editor_id", editorID,
 			"newsletter_editor_id", newsletter.EditorId.String())
-		return nil, models.NewForbiddenError("SERVICE: You don't have access to this newsletter")
+		return nil, models.NewForbiddenError("You don't have access to this newsletter")
 	}
 
 	// Proceed with update

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"context"
+	"go-newsletter/internal/models"
+	"go-newsletter/internal/repository"
+	"go-newsletter/pkg/generated"
+	"log/slog"
+)
+
+type NewsletterService struct {
+	repo   *repository.NewsletterRepository
+	logger *slog.Logger
+}
+
+func NewNewsletterService(repo *repository.NewsletterRepository, logger *slog.Logger) *NewsletterService {
+	return &NewsletterService{
+		repo:   repo,
+		logger: logger,
+	}
+}
+
+func (s *NewsletterService) GetNewslettersOwnedByEditor(ctx context.Context, editorId string) ([]generated.Newsletter, error) {
+	newsletters, err := s.repo.GetNewslettersOwnedByEditor(ctx, editorId)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "SERVICE: failed to find newsletters of current editor", "error", err)
+		return nil, err
+	}
+
+	var result []generated.Newsletter
+	for _, n := range newsletters {
+		result = append(result, n)
+	}
+	return result, nil
+}
+
+func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterId string, editorId string) (*generated.Newsletter, error) {
+	newsletter, err := s.repo.GetByID(ctx, newsletterId)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "SERVICE: failed to get newsletter by ID", "error", err)
+		return nil, err
+	}
+
+	// Check if the requesting user is the editor of this newsletter
+	if newsletter.EditorId.String() != editorId {
+		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
+			"requested_editor_id", editorId,
+			"newsletter_editor_id", newsletter.EditorId.String())
+		return nil, models.NewForbiddenError("You don't have access to this newsletter")
+	}
+
+	return newsletter, nil
+}
+
+func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorId string, newsletterCreate generated.NewsletterCreate) (*generated.Newsletter, error) {
+	newsletter, err := s.repo.Create(ctx, editorId, &newsletterCreate)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "SERVICE: failed to create newsletter", "error", err)
+		return nil, err
+	}
+	return newsletter, nil
+}

--- a/internal/services/newsletter_service.go
+++ b/internal/services/newsletter_service.go
@@ -46,7 +46,7 @@ func (s *NewsletterService) GetNewsletterByID(ctx context.Context, newsletterId 
 		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
 			"requested_editor_id", editorId,
 			"newsletter_editor_id", newsletter.EditorId.String())
-		return nil, models.NewForbiddenError("You don't have access to this newsletter")
+		return nil, models.NewForbiddenError("SERVICE: You don't have access to this newsletter")
 	}
 
 	return newsletter, nil
@@ -58,5 +58,23 @@ func (s *NewsletterService) CreateNewsletter(ctx context.Context, editorId strin
 		s.logger.ErrorContext(ctx, "SERVICE: failed to create newsletter", "error", err)
 		return nil, err
 	}
+	return newsletter, nil
+}
+
+func (s *NewsletterService) UpdateNewsletter(ctx context.Context, editorId string, newsletterId string, newsletterUpdate generated.NewsletterUpdate) (*generated.Newsletter, error) {
+	newsletter, err := s.repo.Update(ctx, newsletterId, &newsletterUpdate)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "SERVICE: failed to update newsletter", "error", err)
+		return nil, err
+	}
+
+	// Check if the requesting user is the editor of this newsletter
+	if newsletter.EditorId.String() != editorId {
+		s.logger.WarnContext(ctx, "SERVICE: unauthorized access attempt",
+			"requested_editor_id", editorId,
+			"newsletter_editor_id", newsletter.EditorId.String())
+		return nil, models.NewForbiddenError("SERVICE: You don't have access to this newsletter")
+	}
+
 	return newsletter, nil
 }


### PR DESCRIPTION
Implementovany nasledujici endpoints:
![image](https://github.com/user-attachments/assets/463455c4-0ea5-4ae4-bf9a-9921d3b7b6f1)
![image](https://github.com/user-attachments/assets/170b1b6f-9e88-4451-ba8f-7599c628be6b)

service vrstva provadi zakladni validace - delky stringu, prazdna pole, 1 editor nemuze mit vice stejne pojmenovanych newsletteru, vice viz newsletter_config.go.
V configu jsou definovane i error messages pro newslettery. Coz si nejsem jisty jestli je spravne architektonicky, ale dava mi to smysl, protoze ty hlasky jsou specificke pro newslettery.


protoze se mi nenacital .env (main.go ho hledal ve stejnem adresari a ne v rootu) nechal jsem si pridat funkci, ktera najde root projektu a hleda .env tam. vice viz [mattermost vlakno](https://mattermost.hatrinh.cz/go/pl/cxj6kmen47yndcxhz97q5ajmxa) - pokud ma nekdo lepsi napad tak sem s nim :D

